### PR TITLE
Fix warnings and errors when compliling with C++20

### DIFF
--- a/benchmark/k-means.cpp
+++ b/benchmark/k-means.cpp
@@ -68,7 +68,7 @@ class CommandLineOptions {
         cxxopts::ParseResult options;
         try {
             options = cliParser.parse(argc, argv);
-        } catch (cxxopts::OptionException& e) {
+        } catch (cxxopts::exceptions::exception& e) {
             std::cout << e.what() << std::endl << std::endl;
             std::cout << cliParser.help() << std::endl;
             exit(1);

--- a/benchmark/pageRank.cpp
+++ b/benchmark/pageRank.cpp
@@ -525,7 +525,7 @@ int main(int argc, char** argv) {
     cxxopts::ParseResult options;
     try {
         options = cliParser.parse(argc, argv);
-    } catch (cxxopts::OptionException& e) {
+    } catch (cxxopts::exceptions::exception& e) {
         if (myRank == 0) {
             std::cout << e.what() << std::endl << std::endl;
             std::cout << cliParser.help() << std::endl;

--- a/benchmark/simulate_failures_until_data_loss.cpp
+++ b/benchmark/simulate_failures_until_data_loss.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
     cxxopts::ParseResult options;
     try {
         options = cliParser.parse(argc, argv);
-    } catch (cxxopts::OptionException& e) {
+    } catch (cxxopts::exceptions::exception& e) {
         std::cout << e.what() << std::endl << std::endl;
         std::cout << cliParser.help() << std::endl;
         exit(1);

--- a/include/restore/block_serialization.hpp
+++ b/include/restore/block_serialization.hpp
@@ -47,10 +47,10 @@ class SerializedBlockStoreStream {
     }
 
     // Keep the user from copying or moving our SerializedBlockStore object we pass to him.
-    SerializedBlockStoreStream(const SerializedBlockStoreStream&) = delete;
-    SerializedBlockStoreStream(SerializedBlockStoreStream&&)      = delete;
+    SerializedBlockStoreStream(const SerializedBlockStoreStream&)            = delete;
+    SerializedBlockStoreStream(SerializedBlockStoreStream&&)                 = delete;
     SerializedBlockStoreStream& operator=(const SerializedBlockStoreStream&) = delete;
-    SerializedBlockStoreStream& operator=(SerializedBlockStoreStream&&) = delete;
+    SerializedBlockStoreStream& operator=(SerializedBlockStoreStream&&)      = delete;
 
     // reserve()
     //
@@ -399,7 +399,7 @@ class SerializedBlockStorage {
     const BlockDistribution<MPIContext>&   _blockDistribution;
 
     struct WritingState {
-        WritingState(BlockRange _range, std::vector<std::byte>& _data) : range(_range), data(_data) {}
+        WritingState(BlockRange _range, std::vector<std::byte>& _data) noexcept : range(_range), data(_data) {}
 
         BlockRange              range;
         std::vector<std::byte>& data;

--- a/include/restore/block_serialization.hpp
+++ b/include/restore/block_serialization.hpp
@@ -63,10 +63,10 @@ class SerializedBlockStoreStream {
 
     // operator<<
     //
-    // Can be used to serialize a plain old datatype (pod)
+    // Can be used to serialize a trivially copyable type
     template <class T>
     inline SerializedBlockStoreStream& operator<<(const T& value) {
-        static_assert(std::is_pod<T>(), "You may only serialize a POD this way.");
+        static_assert(std::is_trivially_copyable<T>(), "You may only serialize a trivially copyable type this way.");
 
         auto src = reinterpret_cast<const std::byte*>(&value);
         for (auto buffer: _outputBuffers) {
@@ -173,7 +173,7 @@ class SerializedBlockStoreStream {
 
     template <class T>
     void writeToReservedBytes(WritableStreamPosition& position, const T& value) {
-        static_assert(std::is_pod<T>(), "You may only serialize a POD this way.");
+        static_assert(std::is_trivially_copyable<T>(), "You may only serialize a trivially copyable type this way.");
         assert(sizeof(T) <= position.length);
 
         auto src = reinterpret_cast<const std::byte*>(&value);

--- a/include/restore/block_submission.hpp
+++ b/include/restore/block_submission.hpp
@@ -157,7 +157,7 @@ class BlockSubmissionCommunication {
         private:
         using WritableStreamPosition = SerializedBlockStoreStream::WritableStreamPosition;
         struct IDRangeState {
-            IDRangeState(BlockIDRange _range, WritableStreamPosition _positionInStream)
+            IDRangeState(BlockIDRange _range, WritableStreamPosition _positionInStream) noexcept
                 : range(_range),
                   positionInStream(_positionInStream) {}
             BlockIDRange           range;
@@ -195,10 +195,10 @@ class BlockSubmissionCommunication {
             assert(_dataStream.size() >= DESCRIPTOR_SIZE);
         }
 
-        BlockIDDeserialization()                              = delete;
-        BlockIDDeserialization(BlockIDDeserialization&&)      = delete;
-        BlockIDDeserialization(const BlockIDDeserialization&) = delete;
-        BlockIDDeserialization& operator=(BlockIDDeserialization&&) = delete;
+        BlockIDDeserialization()                                         = delete;
+        BlockIDDeserialization(BlockIDDeserialization&&)                 = delete;
+        BlockIDDeserialization(const BlockIDDeserialization&)            = delete;
+        BlockIDDeserialization& operator=(BlockIDDeserialization&&)      = delete;
         BlockIDDeserialization& operator=(const BlockIDDeserialization&) = delete;
 
         // Returns the next block. If the current range still hast ids left, returns the next one from that

--- a/include/restore/common.hpp
+++ b/include/restore/common.hpp
@@ -23,7 +23,7 @@ using block_id_t = std::size_t;
 // returned by the nextBlock() functions to describe the next block (or nullopt if there is none)
 template <class BlockType>
 struct NextBlock {
-    NextBlock(block_id_t _blockId, const BlockType& _block) : blockId(_blockId), block(_block) {}
+    NextBlock(block_id_t _blockId, const BlockType& _block) noexcept : blockId(_blockId), block(_block) {}
     block_id_t       blockId;
     const BlockType& block;
 };

--- a/include/restore/helpers.hpp
+++ b/include/restore/helpers.hpp
@@ -209,25 +209,25 @@ template <class data_t>
 // Some bit twiddling helper functions.
 template <typename Data>
 constexpr uint8_t num_bits() {
-    static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+    static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
     return sizeof(Data) * 8;
 }
 
 template <typename Data>
 inline int64_t bits_left_half(Data bytes) {
-    static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+    static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
     return bytes >> num_bits<Data>() / 2;
 }
 
 template <typename Data>
 inline int64_t bits_right_half(Data bytes) {
-    static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+    static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
     return bytes & static_cast<Data>(-1) >> num_bits<Data>() / 2;
 }
 
 template <typename Data>
 inline int64_t bits_combine_halves(Data left, Data right) {
-    static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+    static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
     return (left << num_bits<Data> / 2) | right;
 }
 
@@ -237,7 +237,7 @@ inline int64_t bits_combine_halves(Data left, Data right) {
 // content source operand is 0, the content of the destination operand is undefined.
 template <typename Data>
 inline uint8_t most_significant_bit_set(Data bytes) {
-    static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+    static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
 
     if (bytes == 0) {
         return 0;
@@ -405,7 +405,7 @@ class ResultsCSVPrinter {
 
 template <class Data>
 inline XXH64_hash_t xxhash(Data n, XXH64_hash_t seed) {
-    static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+    static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
     return XXH64(&n, sizeof(Data), seed);
 }
 

--- a/include/restore/mpi_context.hpp
+++ b/include/restore/mpi_context.hpp
@@ -353,7 +353,7 @@ class MPIContext {
     // TODO compile time enable exceptions instead of assertions
     template <class data_t>
     void broadcast(data_t* data, size_t numDataElements = 1, int root = 0) {
-        static_assert(std::is_pod_v<data_t>, "broadcast only works for POD data");
+        static_assert(std::is_trivially_copyable_v<data_t>, "broadcast only works for trivially copyable data");
         _possiblySimulateFailure();
         int _numDataElements = asserting_cast<int>(numDataElements);
         return successOrThrowMpiCall(
@@ -362,7 +362,7 @@ class MPIContext {
 
     template <class data_t>
     void allreduce(data_t* data, MPI_Op operation, size_t numDataElements = 1) {
-        static_assert(std::is_pod_v<data_t>, "allreduce only works for POD data");
+        static_assert(std::is_trivially_copyable_v<data_t>, "allreduce only works for trivially copyable data");
         int _numDataElements = asserting_cast<int>(numDataElements);
         _possiblySimulateFailure();
         successOrThrowMpiCall([&]() {
@@ -372,13 +372,13 @@ class MPIContext {
 
     template <class data_t>
     void allreduce(std::vector<data_t>& data, MPI_Op operation) {
-        static_assert(std::is_pod_v<data_t>, "allreduce only works for POD data");
+        static_assert(std::is_trivially_copyable_v<data_t>, "allreduce only works for trivially copyable data");
         allreduce(data.data(), operation, data.size());
     }
 
     template <class data_t>
     data_t allreduce(data_t value, MPI_Op operation) {
-        static_assert(std::is_pod_v<data_t>, "allreduce only works for POD data");
+        static_assert(std::is_trivially_copyable_v<data_t>, "allreduce only works for trivially copyable data");
         allreduce(&value, operation, 1);
         return value;
     }
@@ -396,7 +396,7 @@ class MPIContext {
 
     template <class data_t>
     std::vector<data_t> gatherv(std::vector<data_t>& data, int root = 0) {
-        static_assert(std::is_pod_v<data_t>, "gatherv only works for POD data");
+        static_assert(std::is_trivially_copyable_v<data_t>, "gatherv only works for trivially copyable data");
         _possiblySimulateFailure();
 
         // First, gather the number of data elements per rank
@@ -472,7 +472,7 @@ class MPIContext {
     //// ! Untested
     // template <class data_t>
     // std::vector<data_t> inclusive_scan(data_t value, MPI_Op operation) {
-    //    static_assert(std::is_pod_v<data_t>, "inclusive_scan only works for POD data");
+    //    static_assert(std::is_trivially_copyable_v<data_t>, "inclusive_scan only works for trivially copyable data");
     //    std::vector<data_t> result(getCurrentSize(), 0);
     //    return successOrThrowMpiCall(
     //        [&]() { return MPI_Scan(&value, result, 1, get_mpi_type<data_t>(), operation, _comm); });
@@ -481,7 +481,7 @@ class MPIContext {
 
     template <class data_t>
     data_t exclusive_scan(data_t value, MPI_Op operation) {
-        static_assert(std::is_pod_v<data_t>, "inclusive_scan only works for POD data");
+        static_assert(std::is_trivially_copyable_v<data_t>, "inclusive_scan only works for trivially copyable data");
         _possiblySimulateFailure();
 
         successOrThrowMpiCall(

--- a/include/restore/pseudo_random_permutation.hpp
+++ b/include/restore/pseudo_random_permutation.hpp
@@ -276,7 +276,7 @@ class FeistelPseudoRandomPermutation {
 
     template <class Data>
     inline XXH64_hash_t _xxhash(Data n, XXH64_hash_t key) const {
-        static_assert(std::is_pod_v<Data>, "Data has to be a POD.");
+        static_assert(std::is_trivially_copyable_v<Data>, "Data has to be a trivially copyable type.");
         return XXH64(&n, sizeof(Data), key);
     }
 };


### PR DESCRIPTION
I just compiled with gcc 12.2.0 and C++20 and found some errors and warnings. There is still a warning in `cxxopts` ([I have a PR open for that](https://github.com/jarro2783/cxxopts/pull/391) - update: It got merged and I updated it here in 7e25acfc60ea9a74a239fef159a58c402ff35a2e) and even one in `vector.resize`?? (That seems to be a false positive - [reported to gcc](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108860))

@lukashuebner could you have a look at the replacements of `is_pod` in e099ae49978055165d6a038bf44b129fd8f3ce01? I think everywhere you used it you just wanted to make sure that all the data is contiguous in memory which is what `is_trivially_copyable` gives us.