### PR TITLE
Disable -Wnull-dereference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     list(
         APPEND WARNING_FLAGS
         "-Wcast-align"
-        "-Wnull-dereference"
         "-Wpedantic"
     )
 endif()
@@ -176,7 +175,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     list(
         APPEND WARNING_FLAGS
         "-Wcast-align"
-        "-Wnull-dereference"
         "-Wpedantic"
         "-Wnoexcept"
         "-Wsuggest-attribute=const"


### PR DESCRIPTION
There just seem to be too many problems with this, at least in gcc:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86172
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96554

What do you think? @lukashuebner 