### PR TITLE
Fix modulo mask in lcg permutation

### DIFF
--- a/benchmark/pseudo_random_permutation.cpp
+++ b/benchmark/pseudo_random_permutation.cpp
@@ -8,8 +8,8 @@
     #include <benchmark/benchmark.h>
 #endif
 
-#include "restore/pseudo_random_permutation.hpp"
 #include "restore/helpers.hpp"
+#include "restore/pseudo_random_permutation.hpp"
 
 #include <xxhash.h>
 
@@ -39,7 +39,7 @@ BENCHMARK(BM_Feistel);
 
 static void BM_LCG(benchmark::State& state) {
     // Setup
-    const int64_t MAX_VALUE  = 100000;
+    const uint64_t MAX_VALUE = 100000;
 
     LCGPseudoRandomPermutation permutation(MAX_VALUE);
 
@@ -47,7 +47,7 @@ static void BM_LCG(benchmark::State& state) {
     for (auto _: state) {
         UNUSED(_);
 
-        for (int64_t i = 0; i <= MAX_VALUE; i++) {
+        for (uint64_t i = 0; i <= MAX_VALUE; i++) {
             benchmark::DoNotOptimize(permutation.f(i));
         }
     }

--- a/include/restore/pseudo_random_permutation.hpp
+++ b/include/restore/pseudo_random_permutation.hpp
@@ -11,12 +11,12 @@
 
 class LCGPseudoRandomPermutation {
     public:
-    LCGPseudoRandomPermutation(int64_t max_value) : _max_value(max_value) {
+    LCGPseudoRandomPermutation(uint64_t max_value) : _max_value(max_value) {
         _choose_modulo(_max_value);
         _choose_a();
     }
 
-    int64_t f(int64_t n) const {
+    uint64_t f(uint64_t n) const {
         // We use cycle walking to ensure, that the generated number is at most _max_value
         do {
             n = _mod(n * _a + _c);
@@ -24,25 +24,23 @@ class LCGPseudoRandomPermutation {
         return n;
     }
 
-    int64_t finv(int64_t n) const {
+    uint64_t finv(uint64_t n) const {
         do {
-            // TODO: I think this is undefined because the standard doesn't specify the bit-representation of negative
-            // values
             n = _mod((n - _c) * _ainv);
         } while (n > _max_value);
         return n;
     }
 
     private:
-    int64_t _max_value;
-    int64_t _modulo;
-    int64_t _modulo_and_mask;
-    int64_t _c =
+    uint64_t _max_value;
+    uint64_t _modulo;
+    uint64_t _modulo_and_mask;
+    uint64_t _c =
         1; // Satisfies the Hull-Dobell theorem. The distribution of random numbers is not sensitive to the value of c.
-    int64_t _a    = 0;
-    int64_t _ainv = 0;
+    uint64_t _a    = 0;
+    uint64_t _ainv = 0;
 
-    void _choose_modulo(int64_t max_value) {
+    void _choose_modulo(uint64_t max_value) {
         // See http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
         // Round max_value up to the next highest power of 2.
         max_value--; // In case max_value already is a power of two, we do not want to change it.
@@ -68,12 +66,14 @@ class LCGPseudoRandomPermutation {
         _ainv = _modulo_multiplicative_inverse(_a, _modulo);
     }
 
-    int64_t _mod(int64_t n) const {
+    uint64_t _mod(uint64_t n) const {
         return n & _modulo_and_mask;
     }
 
-    int64_t _modulo_multiplicative_inverse(int64_t a, int64_t m) const {
+    uint64_t _modulo_multiplicative_inverse(uint64_t param_a, uint64_t param_m) const {
         // https://rosettacode.org/wiki/Modular_inverse#C.2B.2B
+        int64_t a  = asserting_cast<int64_t>(param_a);
+        int64_t m  = asserting_cast<int64_t>(param_m);
         int64_t m0 = m, t, q;
         int64_t x0 = 0, x1 = 1;
 
@@ -91,7 +91,7 @@ class LCGPseudoRandomPermutation {
             x1 += m0;
         }
 
-        return x1;
+        return asserting_cast<uint64_t>(x1);
     }
 };
 

--- a/include/restore/pseudo_random_permutation.hpp
+++ b/include/restore/pseudo_random_permutation.hpp
@@ -26,6 +26,8 @@ class LCGPseudoRandomPermutation {
 
     int64_t finv(int64_t n) const {
         do {
+            // TODO: I think this is undefined because the standard doesn't specify the bit-representation of negative
+            // values
             n = _mod((n - _c) * _ainv);
         } while (n > _max_value);
         return n;
@@ -54,7 +56,6 @@ class LCGPseudoRandomPermutation {
 
         _modulo_and_mask = max_value;     // Set all bits except the highest one of the bitmask.
         _modulo          = max_value + 1; // Add 1, which will carry over to the first 0 after all the ones.
-        _modulo_and_mask |= _modulo;      // Set the highest bit of the bitmask.
     }
 
     // TODO: How do we choose a proper a?

--- a/tests/test_pseudo_random_permutation.cpp
+++ b/tests/test_pseudo_random_permutation.cpp
@@ -12,12 +12,12 @@ using namespace ::testing;
 TEST(PseudoRandomPermutationTest, LCG) {
     uint64_t n = 34;
 
-    LCGPseudoRandomPermutation permutation(asserting_cast<int64_t>(n - 1));
-    std::vector<int64_t>       sequence;
+    LCGPseudoRandomPermutation permutation(asserting_cast<uint64_t>(n - 1));
+    std::vector<uint64_t>      sequence;
 
     // Build test vector
     sequence.reserve(n);
-    for (int64_t i = 0; i < asserting_cast<int64_t>(n); ++i) {
+    for (uint64_t i = 0; i < n; ++i) {
         sequence.push_back(i);
     }
 

--- a/tests/test_pseudo_random_permutation.cpp
+++ b/tests/test_pseudo_random_permutation.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <unordered_set>
 
 #include <gmock/gmock.h>
@@ -8,30 +9,32 @@
 
 using namespace ::testing;
 
-// TEST(PseudoRandomPermutationTest, LCG) {
-//    uint64_t n = 10;
-//
-//    LCGPseudoRandomPermutation permutation(asserting_cast<int64_t>(n - 1));
-//    std::vector<uint64_t> sequence;
-//
-//    // Build test vector
-//    sequence.reserve(n);
-//    for (uint64_t i = 0; i < n; ++i) {
-//        sequence.push_back(i);
-//    }
-//
-//    // Apply permutation to every element in the test vector.
-//    for (size_t idx = 0; idx < n; ++idx) {
-//        // Test that the permutation is invertible
-//        ASSERT_EQ(sequence[idx], permutation.finv(permutation.f(sequence[idx])));
-//
-//        // Compute the permutation, to later check that each element only appears once.
-//        sequence[idx] = permutation.f(sequence[idx]);
-//    }
-//
-//    // Check that no element appears more than once. Also check, that we did not exceed the given range.
-//    EXPECT_THAT(sequence, UnorderedElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
-//}
+TEST(PseudoRandomPermutationTest, LCG) {
+    uint64_t n = 34;
+
+    LCGPseudoRandomPermutation permutation(asserting_cast<int64_t>(n - 1));
+    std::vector<int64_t>       sequence;
+
+    // Build test vector
+    sequence.reserve(n);
+    for (int64_t i = 0; i < asserting_cast<int64_t>(n); ++i) {
+        sequence.push_back(i);
+    }
+
+    auto sequence_copy(sequence);
+
+    // Apply permutation to every element in the test vector.
+    for (size_t idx = 0; idx < n; ++idx) {
+        // Test that the permutation is invertible
+        ASSERT_EQ(sequence[idx], permutation.finv(permutation.f(sequence[idx])));
+
+        // Compute the permutation, to later check that each element only appears once.
+        sequence[idx] = permutation.f(sequence[idx]);
+    }
+
+    // Check that no element appears more than once. Also check, that we did not exceed the given range.
+    EXPECT_THAT(sequence, UnorderedElementsAreArray(sequence_copy));
+}
 
 TEST(PseudoRandomPermutationTest, FeistelEvenBitCount) {
     const uint64_t n          = 10;


### PR DESCRIPTION
If the modulo is `1000`, the mask shouldn't be `1111`, but `0111`.